### PR TITLE
Fix path resolving bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ module.exports = {
   },
 
   resolvePackagePath(packageName) {
-    return path.dirname(resolve.sync(`${packageName}/package.json`, { basedir: this.app.project.root }));
+    let host = this._findHost();
+    return path.dirname(resolve.sync(`${packageName}/package.json`, { basedir: host.project.root }));
   },
 
   _ensureFindHost() {


### PR DESCRIPTION
This fixes an issue where `project` was undefined when trying to `ember serve` an addon that depended on ember-cli-bootstrap-4. In this case `this.app` is undefined. Using `_findHost()` here as well (as done everywhere else in the file) solves the issue.